### PR TITLE
Refactoring and fix

### DIFF
--- a/PluginLoader/Compiler/PublicizedAssemblies.cs
+++ b/PluginLoader/Compiler/PublicizedAssemblies.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+
+namespace avaness.PluginLoader.Compiler;
+
+public class PublicizedAssemblies
+{
+    private readonly HashSet<string> ignoredAssemblyNames = new HashSet<string>();
+    private readonly Dictionary<string, MetadataReference> publicizedReferences = new Dictionary<string, MetadataReference>();
+
+    public void InspectSource(SourceText source)
+    {
+        SyntaxTree syntaxTree = CSharpSyntaxTree.ParseText(source);
+        SyntaxNode root = syntaxTree.GetRoot();
+
+        IEnumerable<AttributeSyntax> attributes = root
+            .DescendantNodes()
+            .OfType<AttributeSyntax>()
+            .Where(attr => attr.Name.ToString().EndsWith("IgnoresAccessChecksTo"));
+
+        foreach (var attribute in attributes)
+        {
+            AttributeArgumentSyntax targetAssemblyArg = attribute.ArgumentList.Arguments.FirstOrDefault();
+
+            if (targetAssemblyArg?.Expression is not LiteralExpressionSyntax literalExpression)
+                continue;
+
+            if (literalExpression.IsKind(SyntaxKind.StringLiteralExpression))
+            {
+                string ignoredAssemblyName = literalExpression.Token.ValueText;
+                ignoredAssemblyNames.Add(ignoredAssemblyName);
+            }
+        }
+    }
+
+    public MetadataReference PublicizeReferenceIfRequired(string targetName, string dependencyName, MetadataReference dependency)
+    {
+        if (!ignoredAssemblyNames.Contains(dependencyName))
+            return dependency;
+
+        if (!GetPublicizedReference(dependencyName, dependency, out var publicizedReference))
+            throw new Exception($"Failed to publicize assembly {dependencyName} for {targetName}");
+
+        LogFile.WriteLine($"Using publicized {dependencyName} for {targetName}");
+        return publicizedReference;
+    }
+
+    private bool GetPublicizedReference(string referenceName, MetadataReference originalReference, out MetadataReference publicizedRef)
+    {
+        if (publicizedReferences.TryGetValue(referenceName, out publicizedRef))
+            return true;
+
+        if (originalReference is not PortableExecutableReference portableRef || string.IsNullOrEmpty(portableRef.FilePath))
+            return false;
+
+        publicizedRef = Publicizer.PublicizeReference(portableRef);
+        publicizedReferences.Add(referenceName, publicizedRef);
+
+        return true;
+    }
+}

--- a/PluginLoader/Compiler/RoslynCompiler.cs
+++ b/PluginLoader/Compiler/RoslynCompiler.cs
@@ -40,6 +40,7 @@ namespace avaness.PluginLoader.Compiler
             
             var references = RoslynReferences.AllReferences
                 .Select(kv => publicizedAssemblies.PublicizeReferenceIfRequired(assemblyName, kv.Key, kv.Value))
+                .Concat(customReferences)
                 .ToHashSet();
 
             CSharpCompilation compilation = CSharpCompilation.Create(

--- a/PluginLoader/Compiler/RoslynCompiler.cs
+++ b/PluginLoader/Compiler/RoslynCompiler.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Emit;
 using Microsoft.CodeAnalysis.Text;
 using System;
@@ -13,7 +12,7 @@ namespace avaness.PluginLoader.Compiler
     public class RoslynCompiler
     {
         private readonly List<Source> source = new List<Source>();
-        private readonly HashSet<string> publicized = new HashSet<string>();
+        private readonly PublicizedAssemblies publicizedAssemblies = new PublicizedAssemblies();
         private readonly List<MetadataReference> customReferences = new List<MetadataReference>();
         private bool debugBuild;
 
@@ -31,65 +30,17 @@ namespace avaness.PluginLoader.Compiler
                 source.Add(new Source(mem, name, debugBuild));
 
                 SourceText sourceText = SourceText.From(mem);
-                HashSet<string> ignoredAccess = GetIgnoredAccessAssemblies(sourceText);
-                publicized.UnionWith(ignoredAccess);
+                publicizedAssemblies.InspectSource(sourceText);
             }
-        }
-
-        public static HashSet<string> GetIgnoredAccessAssemblies(SourceText source)
-        {
-            HashSet<string> found = new HashSet<string>();
-
-            SyntaxTree syntaxTree = CSharpSyntaxTree.ParseText(source);
-            SyntaxNode root = syntaxTree.GetRoot();
-
-            IEnumerable<AttributeSyntax> attributes = root.DescendantNodes()
-                .OfType<AttributeSyntax>()
-                .Where(attr => attr.Name.ToString().EndsWith("IgnoresAccessChecksTo"));
-
-            foreach (var attribute in attributes)
-            {
-                AttributeArgumentSyntax targetAssemblyArg = attribute.ArgumentList.Arguments.FirstOrDefault();
-
-                if (targetAssemblyArg?.Expression is not LiteralExpressionSyntax literalExpression)
-                {
-                    continue;
-                }
-
-                if (literalExpression.IsKind(SyntaxKind.StringLiteralExpression))
-                {
-                    string ignoredAssemblyName = literalExpression.Token.ValueText;
-                    found.Add(ignoredAssemblyName);
-                }
-            }
-
-            return found;
         }
 
         public byte[] Compile(string assemblyName, out byte[] symbols)
         {
             symbols = null;
-            var references = new HashSet<MetadataReference>();
-
-            foreach (var reference in RoslynReferences.GetAllReferences())
-            {
-                if (publicized.Contains(reference.Key))
-                {
-                    if (RoslynReferences.GetPublicizedReference(reference.Key, out var publicizedRef))
-                    {
-                        LogFile.WriteLine($"Using publicized {reference.Key} for {assemblyName}");
-                        references.Add(publicizedRef);
-                    }
-                    else
-                    {
-                        throw new Exception("Publicizing failed!");
-                    }
-                }
-                else
-                {
-                    references.Add(reference.Value);
-                }
-            }
+            
+            var references = RoslynReferences.AllReferences
+                .Select(kv => publicizedAssemblies.PublicizeReferenceIfRequired(assemblyName, kv.Key, kv.Value))
+                .ToHashSet();
 
             CSharpCompilation compilation = CSharpCompilation.Create(
                 assemblyName,

--- a/PluginLoader/Compiler/RoslynReferences.cs
+++ b/PluginLoader/Compiler/RoslynReferences.cs
@@ -11,13 +11,12 @@ namespace avaness.PluginLoader.Compiler
 {
     public static class RoslynReferences
     {
-        private static Dictionary<string, MetadataReference> allReferences = new Dictionary<string, MetadataReference>();
-        private static Dictionary<string, MetadataReference> publicizedReferences = new Dictionary<string, MetadataReference>();
+        internal static readonly Dictionary<string, MetadataReference> AllReferences = new Dictionary<string, MetadataReference>();
         private static readonly HashSet<string> referenceBlacklist = new HashSet<string>(new[] { "System.ValueTuple" });
 
         public static void GenerateAssemblyList()
         {
-            if (allReferences.Count > 0)
+            if (AllReferences.Count > 0)
                 return;
 
             AssemblyName harmonyInfo = typeof(HarmonyLib.Harmony).Assembly.GetName();
@@ -48,11 +47,13 @@ namespace avaness.PluginLoader.Compiler
                     AddAssemblyReference(a);
                     sb.AppendLine(a.FullName);
                 }
-                foreach(Assembly a in GetOtherReferences())
+
+                foreach (Assembly a in GetOtherReferences())
                 {
                     AddAssemblyReference(a);
                     sb.AppendLine(a.FullName);
                 }
+
                 sb.AppendLine(line);
                 while (loadedAssemblies.Count > 0)
                 {
@@ -75,6 +76,7 @@ namespace avaness.PluginLoader.Compiler
                         }
                     }
                 }
+
                 sb.AppendLine(line);
             }
             catch (Exception e)
@@ -97,7 +99,7 @@ namespace avaness.PluginLoader.Compiler
 
         private static bool ContainsReference(AssemblyName name)
         {
-            return allReferences.ContainsKey(name.Name);
+            return AllReferences.ContainsKey(name.Name);
         }
 
         private static bool TryLoadAssembly(AssemblyName name, out Assembly aRef)
@@ -114,40 +116,11 @@ namespace avaness.PluginLoader.Compiler
             }
         }
 
-        public static bool GetPublicizedReference(string id, out MetadataReference publicizedRef)
-        {
-            if (publicizedReferences.TryGetValue(id, out publicizedRef))
-            {
-                return true;
-            }
-
-            if (!allReferences.TryGetValue(id, out var targetRef))
-            {
-                return false;
-            }
-
-            if (targetRef is PortableExecutableReference portableRef
-                 && !string.IsNullOrEmpty(portableRef.FilePath))
-            {
-                publicizedRef = Publicizer.PublicizeReference(portableRef);
-                publicizedReferences.Add(id, publicizedRef);
-
-                return true;
-            }
-
-            return false;
-        }
-
         private static void AddAssemblyReference(Assembly a)
         {
             string name = a.GetName().Name;
-            if (!allReferences.ContainsKey(name))
-                allReferences.Add(name, MetadataReference.CreateFromFile(a.Location));
-        }
-
-        public static Dictionary<string, MetadataReference> GetAllReferences()
-        {
-            return allReferences;
+            if (!AllReferences.ContainsKey(name))
+                AllReferences.Add(name, MetadataReference.CreateFromFile(a.Location));
         }
 
         private static bool IsValidReference(Assembly a)
@@ -160,12 +133,12 @@ namespace avaness.PluginLoader.Compiler
             try
             {
                 AssemblyName aName = new AssemblyName(name);
-                if (!allReferences.ContainsKey(aName.Name))
+                if (!AllReferences.ContainsKey(aName.Name))
                 {
                     Assembly a = Assembly.Load(aName);
                     LogFile.WriteLine("Reference added at runtime: " + a.FullName);
                     MetadataReference aRef = MetadataReference.CreateFromFile(a.Location);
-                    allReferences[a.GetName().Name] = aRef;
+                    AllReferences[a.GetName().Name] = aRef;
                 }
             }
             catch (IOException)
@@ -176,7 +149,7 @@ namespace avaness.PluginLoader.Compiler
 
         public static bool Contains(string id)
         {
-            return allReferences.ContainsKey(id);
+            return AllReferences.ContainsKey(id);
         }
     }
 }

--- a/PluginLoader/PluginLoader.csproj
+++ b/PluginLoader/PluginLoader.csproj
@@ -127,6 +127,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Compiler\PublicizedAssemblies.cs" />
     <Compile Include="Compiler\Publicizer.cs" />
     <Compile Include="Compiler\RoslynReferences.cs" />
     <Compile Include="Config\GitHubPluginConfig.cs" />

--- a/PluginLoader/PluginLoader.csproj
+++ b/PluginLoader/PluginLoader.csproj
@@ -199,17 +199,11 @@
     <PackageReference Include="Microsoft.CSharp">
       <Version>4.7.0</Version>
     </PackageReference>
-    <PackageReference Include="Mono.Cecil">
-      <Version>0.11.6</Version>
-    </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
       <Version>13.0.3</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Resolver">
       <Version>6.12.1</Version>
-    </PackageReference>
-    <PackageReference Include="System.Text.Json">
-      <Version>9.0.0</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />


### PR DESCRIPTION
- Reverted adding of unused dependencies
- Refactoring 
- Re-added accidentally removed code concatenating `customReferences` to the list of references

Tested OK with a local development folder of the Better Terminal plugin.
